### PR TITLE
feat(cleanbuild): Remove dist/lib and dist/types as they are redundant with those in root

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   ],
   "main": "dist/blis-models.umd.js",
   "module": "dist/blis-models.es5.js",
-  "typings": "dist/types/blis-models.d.ts",
+  "typings": "dist/blis-models.d.ts",
   "files": [
     "dist"
   ],


### PR DESCRIPTION
https://github.com/alexjoverm/typescript-library-starter/issues/177
