### PR TITLE
Add null and undefineds where needed by blis-sdk

### DIFF
--- a/src/Teach.ts
+++ b/src/Teach.ts
@@ -30,12 +30,12 @@ export interface TeachIdList {
 }
 
 export interface TeachWithHistory {
-  teach: Teach
+  teach: Teach | undefined
   history: any[]
   memories: Memory[]
   prevMemories: Memory[]
   dialogMode: DialogMode
-  scoreResponse: ScoreResponse
-  scoreInput: ScoreInput
+  scoreResponse: ScoreResponse | undefined
+  scoreInput: ScoreInput | undefined
   discrepancies: string[]
 }

--- a/src/Template.ts
+++ b/src/Template.ts
@@ -3,7 +3,7 @@ export interface Template {
   name: string
   variables: TemplateVariable[]
   body?: string
-  validationError: string
+  validationError: string | null
 }
 
 export interface TemplateVariable {


### PR DESCRIPTION
In other words, blis-sdk will attempt to set the properties of these interfaces to null/undefined but it was not allowed by blis-models.

Temporary solution is to update the blis-models but ideally there would be separate interfaces without these optional parameters.

