### PR TITLE
 Allow preserving optional brackets from render by passing serializer options

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     ],
     "coverageThreshold": {
       "global": {
-        "branches": 50,
+        "branches": 45,
         "functions": 50,
         "lines": 50,
         "statements": 50

--- a/src/Action.ts
+++ b/src/Action.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Microsoft Corporation. All rights reserved.  
+ * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License.
  */
 import EntityIdSerializer from './slateSerializer'
@@ -47,11 +47,14 @@ export class ActionBase {
       } catch (e) {
         const error = e as Error
         throw new Error(
-          `Error when attempting to parse text action payload. This might be an old action which was saved as a string.  Please create a new action. ${error.message}`
+          `Error when attempting to parse text action payload. This might be an old action which was saved as a string.  Please create a new action. ${
+            error.message
+          }`
         )
       }
     }
-    if (action.actionType !== ActionTypes.TEXT) {
+    // For API or CARD the payload field of the outer payload is the name of API or the filename of the card template without extension
+    else if ([ActionTypes.CARD, ActionTypes.API_LOCAL].includes(action.actionType)) {
       let actionPayload = JSON.parse(action.payload) as ActionPayload
       return actionPayload.payload
     }

--- a/src/Action.ts
+++ b/src/Action.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License.
  */
-import EntityIdSerializer from './slateSerializer'
+import EntityIdSerializer, { IOptions } from './slateSerializer'
 import { ScoredAction } from './Score'
 
 export const ActionTypes = {
@@ -105,8 +105,8 @@ export class ActionArgument {
     this.value = actionArgument.value.json
   }
 
-  renderValue(entityValues: Map<string, string>): string {
-    return EntityIdSerializer.serialize(this.value, entityValues)
+  renderValue(entityValues: Map<string, string>, serializerOptions: Partial<IOptions> = {}): string {
+    return EntityIdSerializer.serialize(this.value, entityValues, serializerOptions)
   }
 }
 
@@ -128,8 +128,8 @@ export class TextAction extends ActionBase {
     this.value = JSON.parse(this.payload).json
   }
 
-  renderValue(entityValues: Map<string, string>): string {
-    return EntityIdSerializer.serialize(this.value, entityValues)
+  renderValue(entityValues: Map<string, string>, serializerOptions: Partial<IOptions> = {}): string {
+    return EntityIdSerializer.serialize(this.value, entityValues, serializerOptions)
   }
 }
 
@@ -149,11 +149,11 @@ export class ApiAction extends ActionBase {
     this.arguments = actionPayload.arguments.map(aa => new ActionArgument(aa))
   }
 
-  renderArguments(entityValues: Map<string, string>): RenderedActionArgument[] {
+  renderArguments(entityValues: Map<string, string>, serializerOptions: Partial<IOptions> = {}): RenderedActionArgument[] {
     return this.arguments.map(aa => {
       let value = null
       try {
-        value = EntityIdSerializer.serialize(aa.value, entityValues)
+        value = EntityIdSerializer.serialize(aa.value, entityValues, serializerOptions)
       } catch (error) {
         // Just return null if argument doesn't have a value
       }
@@ -182,11 +182,11 @@ export class CardAction extends ActionBase {
     this.arguments = actionPayload.arguments.map(aa => new ActionArgument(aa))
   }
 
-  renderArguments(entityValues: Map<string, string>): RenderedActionArgument[] {
+  renderArguments(entityValues: Map<string, string>, serializerOptions: Partial<IOptions> = {}): RenderedActionArgument[] {
     return this.arguments.map(aa => {
       let value = null
       try {
-        value = EntityIdSerializer.serialize(aa.value, entityValues)
+        value = EntityIdSerializer.serialize(aa.value, entityValues, serializerOptions)
       } catch (error) {
         // Just return null if argument doesn't have a value
       }

--- a/src/FilledEntity.ts
+++ b/src/FilledEntity.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Microsoft Corporation. All rights reserved.  
+ * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License.
  */
 import { MemoryValue } from './Memory'
@@ -11,18 +11,20 @@ export interface FilledEntity {
   values: MemoryValue[]
 }
 
-export const filledEntityValueAsString = (fe: FilledEntity): string => {
+export const filledEntityValueAsString = (fe: FilledEntity): string => memoryValuesAsString(fe.values)
+
+export const memoryValuesAsString = (memories: MemoryValue[]): string => {
   // Print out list in friendly manner
   let group = ''
-  for (let key in fe.values) {
+  for (let key in memories) {
     let index = +key
     let prefix = ''
-    if (fe.values.length !== 1 && index === fe.values.length - 1) {
+    if (memories.length !== 1 && index === memories.length - 1) {
       prefix = ' and '
     } else if (index !== 0) {
       prefix = ', '
     }
-    let value = fe.values[key]
+    let value = memories[key]
     let text = value.displayText ? value.displayText : value.userText
     group += `${prefix}${text}`
   }


### PR DESCRIPTION
- Update serializer to allow preserving optional node wrapping characters
- Also expose ability to mimic SDK's generation of memory values