### PR TITLE
fix: error when display prebuilts with no resolution

### DIFF
--- a/src/FilledEntity.ts
+++ b/src/FilledEntity.ts
@@ -160,14 +160,22 @@ export class FilledEntityMap {
     builtinType: string | null = null,
     resolution: any | null = null
   ): void {
+    // If we don't already have entry in map for this item, create one
     if (!this.map[entityName]) {
       this.map[entityName] = {
-        entityId: entityId,
+        entityId,
         values: []
       }
     }
 
-    let displayText = builtinType ? ModelUtils.PrebuiltDisplayText(builtinType, resolution, entityValue) : entityValue
+    const displayText = builtinType && resolution ? ModelUtils.PrebuiltDisplayText(builtinType, resolution, entityValue) : entityValue
+
+    const newFilledEntityValue = {
+      userText: entityValue,
+      displayText,
+      builtinType,
+      resolution
+    }
 
     const filledEntity = this.map[entityName]
     // Check if entity buckets values
@@ -175,15 +183,10 @@ export class FilledEntityMap {
       // Add if not a duplicate
       const containsDuplicateValue = filledEntity.values.some(memoryValue => memoryValue.userText === entityValue)
       if (!containsDuplicateValue) {
-        filledEntity.values.push({
-          userText: entityValue,
-          displayText: displayText,
-          builtinType: builtinType,
-          resolution: resolution
-        })
+        filledEntity.values.push(newFilledEntityValue)
       }
     } else {
-      filledEntity.values = [{ userText: entityValue, displayText: displayText, builtinType: builtinType, resolution: resolution }]
+      filledEntity.values = [newFilledEntityValue]
     }
   }
 

--- a/src/ModelUtils.ts
+++ b/src/ModelUtils.ts
@@ -204,12 +204,16 @@ export class ModelUtils {
     }
   }
 
-  public static PrebuiltDisplayText(prebuiltType: string, resolution: any, entityText: string): string {
-    if (prebuiltType.startsWith('builtin.encyclopedia')) {
+  public static PrebuiltDisplayText(builtinType: string, resolution: any, entityText: string): string {
+    if (!builtinType || !resolution) {
       return entityText
     }
 
-    switch (prebuiltType) {
+    if (['builtin.geography', 'builtin.encyclopedia'].some(prefix => builtinType.startsWith(prefix))) {
+      return entityText
+    }
+
+    switch (builtinType) {
       case 'builtin.datetimeV2.date':
         let date = resolution.values[0].value
         if (resolution.values[1]) {
@@ -246,14 +250,6 @@ export class ModelUtils {
         return resolution.value
       case 'builtin.percentage':
         return resolution.value
-      case 'builtin.geography.city':
-        return resolution.value
-      case 'builtin.geography.country':
-        return resolution.value
-      case 'builtin.geography.pointOfInterest':
-        return resolution.value
-      case 'builtin.encyclopedia':
-        return entityText
       default:
         return entityText
     }


### PR DESCRIPTION
I noticed that some prebuilt types do not return resolution field such as `builtin.geography`.  Code was incorrectly assuming all prebuilts have a `resolution.value` field and throwing error when attempting to access `value` of `null` resolution.   Code now will return the `entityText` if resolution is falsy