### PR TITLE
fix: Add AppDefinitionChange to hold transformations

### DIFF
--- a/src/Action.ts
+++ b/src/Action.ts
@@ -108,6 +108,11 @@ export interface TextPayload {
   json: object
 }
 
+export interface ActionPayloadSingleArguments {
+  payload: string
+  arguments: IActionArgument[]
+}
+
 export interface ActionPayload {
   payload: string
   logicArguments: IActionArgument[]
@@ -173,7 +178,24 @@ export class ApiAction extends ActionBase {
       throw new Error(`You attempted to create api action from action of type: ${action.actionType}`)
     }
 
-    const actionPayload: ActionPayload = JSON.parse(this.payload)
+    // const actionPayload: ActionPayload = JSON.parse(this.payload)
+    /**
+     * For backwards-compatibility we must check if the action payload has old 'arguments'
+     * array.  If so, convert it up to the new arguments.
+     */
+    let actionPayload: ActionPayload
+    const untypedActionPayload: any = JSON.parse(this.payload)
+    if (Array.isArray(untypedActionPayload.arguments)) {
+      const legacyActionPayload: ActionPayloadSingleArguments = untypedActionPayload
+      actionPayload = {
+        payload: legacyActionPayload.payload,
+        logicArguments: legacyActionPayload.arguments,
+        renderArguments: []
+      }
+    } else {
+      actionPayload = untypedActionPayload
+    }
+
     this.name = actionPayload.payload
     this.logicArguments = actionPayload.logicArguments.map(aa => new ActionArgument(aa))
     this.renderArguments = actionPayload.renderArguments.map(aa => new ActionArgument(aa))

--- a/src/Action.ts
+++ b/src/Action.ts
@@ -178,24 +178,7 @@ export class ApiAction extends ActionBase {
       throw new Error(`You attempted to create api action from action of type: ${action.actionType}`)
     }
 
-    // const actionPayload: ActionPayload = JSON.parse(this.payload)
-    /**
-     * For backwards-compatibility we must check if the action payload has old 'arguments'
-     * array.  If so, convert it up to the new arguments.
-     */
-    let actionPayload: ActionPayload
-    const untypedActionPayload: any = JSON.parse(this.payload)
-    if (Array.isArray(untypedActionPayload.arguments)) {
-      const legacyActionPayload: ActionPayloadSingleArguments = untypedActionPayload
-      actionPayload = {
-        payload: legacyActionPayload.payload,
-        logicArguments: legacyActionPayload.arguments,
-        renderArguments: []
-      }
-    } else {
-      actionPayload = untypedActionPayload
-    }
-
+    const actionPayload: ActionPayload = JSON.parse(this.payload)
     this.name = actionPayload.payload
     this.logicArguments = actionPayload.logicArguments.map(aa => new ActionArgument(aa))
     this.renderArguments = actionPayload.renderArguments.map(aa => new ActionArgument(aa))

--- a/src/AppDefinition.ts
+++ b/src/AppDefinition.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Microsoft Corporation. All rights reserved.  
+ * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License.
  */
 import { EntityBase } from './Entity'
@@ -10,4 +10,9 @@ export interface AppDefinition {
   entities: EntityBase[]
   actions: ActionBase[]
   trainDialogs: TrainDialog[]
+}
+
+export interface AppDefinitionChange {
+  currentAppDefinition: AppDefinition
+  updatedAppDefinition: AppDefinition | undefined
 }

--- a/src/AppDefinition.ts
+++ b/src/AppDefinition.ts
@@ -5,6 +5,7 @@
 import { EntityBase } from './Entity'
 import { ActionBase } from './Action'
 import { TrainDialog } from './TrainDialog'
+import { AppBase } from './App'
 
 export interface AppDefinition {
   entities: EntityBase[]
@@ -12,7 +13,28 @@ export interface AppDefinition {
   trainDialogs: TrainDialog[]
 }
 
-export interface AppDefinitionChange {
+export interface AppDefinitionChanges {
+  entities: IChangeResult<EntityBase>[]
+  actions: IChangeResult<ActionBase>[]
+  trainDialogs: IChangeResult<TrainDialog>[]
+}
+
+export interface AppDefinitionWithoutChange {
+  isChanged: false
   currentAppDefinition: AppDefinition
-  updatedAppDefinition: AppDefinition | undefined
+}
+
+export interface AppDefinitionWithChange {
+  isChanged: true
+  currentAppDefinition: AppDefinition
+  updatedAppDefinition: AppDefinition
+  appDefinitionChanges: AppDefinitionChanges
+}
+
+export type AppDefinitionChange = AppDefinitionWithChange | AppDefinitionWithoutChange
+
+export interface IChangeResult<T> {
+  isChanged: boolean
+  value: T
+  changes: string[]
 }


### PR DESCRIPTION
When a model is upgraded by the SDK before being passed back to the UI the set of changes must be visible by the user so they can confirm and accept them. This object allows us to store a description of each change performed on an object (action, entity, etc)