### PR TITLE
fix: reduce appveyor builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ npm run build
 npm test
 ```
 
+
 ### Importing library
 
 ```typescript

--- a/README.md
+++ b/README.md
@@ -19,7 +19,6 @@ npm run build
 npm test
 ```
 
-
 ### Importing library
 
 ```typescript

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,15 +6,6 @@ branches:
 
 skip_tags: true
 
-skip_commits:
-  files:
-    - README.md
-    - code-of-conduct.md
-    - CONTRIBUTING.md
-    - LICENSE
-    - .circleci/*
-    - .vscode/*
-
 cache:
   - '%AppData%\npm-cache -> appveyor.yml'
   - node_modules -> package-lock.json

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,20 @@
 skip_branch_with_pr: true
 
+branches:
+  only:
+    - master
+
+skip_tags: true
+
+skip_commits:
+  files:
+    - README.md
+    - code-of-conduct.md
+    - CONTRIBUTING.md
+    - LICENSE
+    - .circleci/*
+    - .vscode/*
+
 cache:
   - '%AppData%\npm-cache -> appveyor.yml'
   - node_modules -> package-lock.json


### PR DESCRIPTION
Attempt to prevent double builds from appveyor

I thought the `skip_branch_with_pr: true` should have done it but we can try more aggressive constraints