### PR TITLE
fix: sourceDialogId type mismatch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3610,8 +3610,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3632,14 +3631,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3654,20 +3651,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3784,8 +3778,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3797,7 +3790,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3812,7 +3804,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3820,14 +3811,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -3846,7 +3835,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3927,8 +3915,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3940,7 +3927,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4026,8 +4012,7 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -4063,7 +4048,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -4083,7 +4067,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -4127,14 +4110,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },

--- a/src/ModelUtils.ts
+++ b/src/ModelUtils.ts
@@ -141,7 +141,8 @@ export class ModelUtils {
   public static ToTrainDialog(
     logDialog: LogDialog,
     actions: ActionBase[] | null = null,
-    entities: EntityBase[] | null = null
+    entities: EntityBase[] | null = null,
+    setSourceId: boolean = false
   ): TrainDialog {
     let trainRounds: TrainRound[] = []
     for (let logRound of logDialog.rounds) {
@@ -164,7 +165,9 @@ export class ModelUtils {
       packageCreationId: 0,
       packageDeletionId: 0,
       trainDialogId: '',
-      sourceLogDialogId: undefined,
+      sourceLogDialogId: setSourceId
+        ? logDialog.logDialogId
+        : undefined,
       version: 0,
       rounds: trainRounds,
       definitions: appDefinition,

--- a/src/ModelUtils.ts
+++ b/src/ModelUtils.ts
@@ -164,7 +164,7 @@ export class ModelUtils {
       packageCreationId: 0,
       packageDeletionId: 0,
       trainDialogId: '',
-      sourceLogDialogId: logDialog.logDialogId,
+      sourceLogDialogId: undefined,
       version: 0,
       rounds: trainRounds,
       definitions: appDefinition,

--- a/src/TrainDialog.ts
+++ b/src/TrainDialog.ts
@@ -56,7 +56,7 @@ export enum Validity {
 }
 
 export interface TrainDialogInput {
-  sourceLogDialogId: string
+  sourceLogDialogId?: string
   rounds: TrainRound[]
   definitions?: AppDefinition | null
   validity?: Validity


### PR DESCRIPTION
Downstream change to fix the Log dialogs from disappearing after an insert of input, action, or various other things.

For such a small change this took over 4 hours to debug and find the source problem then link project  and test the changes. Again related to the schema merge we keep putting off... 

The type was wrong on the models project so in the associated `ToTrainDialog` it was mistakenly set.
This is set on the server when creating a teach session
`trainDialog.SourceLogDialogId = createTeachParams.SourceLogDialogId;`

`sourceLogDialog.TargetTrainDialogIds = sourceLogDialog.TargetTrainDialogIds.Concat(new[] { newTeachSession.TrainDialog });`

I think most of the places we were using `ToTrainDialog` on the client were to create a temporary object, this temporary object which had a `sourceLogDialogId` eventually was sent to the server for creating teach sessions during insert and other operations which was setting then calling:

`sourceLogDialog.TargetTrainDialogIds = sourceLogDialog.TargetTrainDialogIds.Concat(new[] { newTeachSession.TrainDialog });`

which was finally setting `targetTrainDialogIds`

