### PR TITLE
chore: allow callbacks to set if function was given

### DIFF
--- a/src/Callback.ts
+++ b/src/Callback.ts
@@ -7,5 +7,7 @@
 export interface Callback {
   name: string
   logicArguments: string[]
+  isLogicFunctionProvided: boolean
   renderArguments: string[]
+  isRenderFunctionProvided: boolean
 }


### PR DESCRIPTION
Related to only showing the functions defined in the callback: 
https://github.com/Microsoft/ConversationLearner-UI/pull/1065
https://github.com/Microsoft/ConversationLearner-SDK/pull/430