### PR TITLE
chore: normalize ci builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/node:8.11.2-browsers
+      - image: circleci/node:lts
     steps:
       - checkout
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ jobs:
 
       - run: node --version
       - run: npm --version
-      - run: npm install
+      - run: npm ci
 
       - save_cache:
           paths:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,10 @@ branches:
     - master
     - /^greenkeeper/.*$/
 
-
+cache:
+  directories:
+    - ~/.npm
+    - ~/.cache
 
 notifications:
   email: false
@@ -13,6 +16,9 @@ notifications:
 node_js:
   - node
 
+install:
+  - npm ci
+  
 script:
   - npm run test:prod
   - npm run build

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,17 +1,16 @@
 skip_branch_with_pr: true
+skip_tags: true
 
 branches:
   only:
     - master
-
-skip_tags: true
 
 cache:
   - '%AppData%\npm-cache -> appveyor.yml'
   - node_modules -> package-lock.json
   
 install:
-  - npm install
+  - npm ci
 
 before_build:
   # Output useful info for debugging.


### PR DESCRIPTION
After investigating more into travis failures I realized our CI build definitions for the SDK and Models repo were out of date/sync to the UI repo. Will be updating these in both repos so it's consistent.