### PR TITLE
feat: add set entity actions

### DIFF
--- a/src/Action.ts
+++ b/src/Action.ts
@@ -281,3 +281,27 @@ export class SessionAction extends ActionBase {
     return EntityIdSerializer.serialize(this.value, entityValues, serializerOptions)
   }
 }
+
+export type SetEntityPayload = {
+  entityId: string
+  enumValueId: string
+}
+
+export class SetEntityAction extends ActionBase {
+  entityId: string
+  enumValueId: string
+
+  constructor(action: ActionBase) {
+    super(action)
+
+    if (action.actionType !== ActionTypes.SET_ENTITY) {
+      throw new Error(`You attempted to create set entity action from action of type: ${action.actionType}`)
+    }
+
+    // TODO: Server already has actual entityId and enumValueId values, should not need to use payload like this
+    // but some things like scored action only have the payload
+    const jsonPayload = JSON.parse(this.payload) as SetEntityPayload
+    this.entityId = jsonPayload.entityId
+    this.enumValueId = jsonPayload.enumValueId
+  }
+}

--- a/src/Action.ts
+++ b/src/Action.ts
@@ -9,7 +9,8 @@ export enum ActionTypes {
   TEXT = 'TEXT',
   API_LOCAL = 'API_LOCAL',
   CARD = 'CARD',
-  END_SESSION = 'END_SESSION'
+  END_SESSION = 'END_SESSION',
+  SET_ENTITY = 'SET_ENTITY',
 }
 
 export enum ConditionType {
@@ -37,6 +38,8 @@ export class ActionBase {
   version: number
   packageCreationId: number
   packageDeletionId: number
+  entityId: string | undefined
+  enumValueId: string | undefined
 
   constructor(action: ActionBase) {
     this.actionId = action.actionId
@@ -53,6 +56,8 @@ export class ActionBase {
     this.version = action.version
     this.packageCreationId = action.packageCreationId
     this.packageDeletionId = action.packageDeletionId
+    this.entityId = action.entityId
+    this.enumValueId = action.enumValueId
   }
 
   // TODO: Refactor away from generic GetPayload for different action types

--- a/src/ReplayError.ts
+++ b/src/ReplayError.ts
@@ -29,7 +29,8 @@ export enum ReplayErrorType {
   InputAfterNonWait = 'InputAfterNonWait',
   /* Exception */
   Exception = 'Exception',
-  EntityDiscrepancy = 'EntityDiscrepancy'
+  EntityDiscrepancy = 'EntityDiscrepancy',
+  SetEntityException = 'SetEntityException',
 }
 
 export enum ReplayErrorLevel {
@@ -126,5 +127,14 @@ export class ReplayErrorInputAfterNonWait extends ReplayError {
 export class ReplayErrorException extends ReplayError {
   constructor() {
     super(ReplayErrorType.Exception, ReplayErrorLevel.BLOCKING)
+  }
+}
+
+// TODO: Why do we have two types for the same errors?
+// This makes it possible for them to be mismatched.
+// E.g. API exception error could be a InputAfterNoWait error which should be impossible
+export class ReplaySetEntityException extends ReplayError {
+  constructor() {
+    super(ReplayErrorType.SetEntityException, ReplayErrorLevel.ERROR)
   }
 }

--- a/src/action.test.ts
+++ b/src/action.test.ts
@@ -29,7 +29,9 @@ const createEmptyAction = (): ActionBase => ({
   version: 0,
   packageCreationId: 0,
   packageDeletionId: 0,
-  actionType: ActionTypes.TEXT
+  actionType: ActionTypes.TEXT,
+  entityId: undefined,
+  enumValueId: undefined,
 })
 
 const expectedSimpleTextPayload = 'simple text payload'
@@ -214,7 +216,9 @@ describe('Action', () => {
         suggestedEntity: 'fake-action',
         version: 1,
         packageCreationId: 1,
-        packageDeletionId: 0
+        packageDeletionId: 0,
+        entityId: undefined,
+        enumValueId: undefined,
       }
 
       // Act
@@ -242,7 +246,9 @@ describe('Action', () => {
         suggestedEntity: 'fake-action',
         version: 1,
         packageCreationId: 1,
-        packageDeletionId: 0
+        packageDeletionId: 0,
+        entityId: undefined,
+        enumValueId: undefined,
       })
 
       // Act
@@ -268,7 +274,9 @@ describe('Action', () => {
         suggestedEntity: 'fake-action',
         version: 1,
         packageCreationId: 1,
-        packageDeletionId: 0
+        packageDeletionId: 0,
+        entityId: undefined,
+        enumValueId: undefined,
       })
 
       // Act


### PR DESCRIPTION
- Add new ActionType: SET_ENTITY
- Added `entityId` and `enumValueId` to actions
- Add new specific action: `SetEntityAction` in order to parse the payload used in ScoreActions which are not regular actions and don't have the `entityId` or `enumValueId` available
- Add new error type `ReplaySetEntityException`.  We currently don't allow deleting entities if they were used in a SET_ENTITY action so it shouldn't be possible to create this but it's there for consistency.  Maybe in the future we do allow deletion so the SDK would throw error when calling `TakeSetEntityAction` since the entity doesn't exist and this would be sent.