### PR TITLE
fix: make expected entity undefined to match server

### DIFF
--- a/src/Action.ts
+++ b/src/Action.ts
@@ -34,7 +34,7 @@ export class ActionBase {
   negativeEntities: string[] = []
   requiredConditions: Condition[] = []
   negativeConditions: Condition[] = []
-  suggestedEntity: string | null = null
+  suggestedEntity: string | undefined
   version: number
   packageCreationId: number
   packageDeletionId: number
@@ -52,7 +52,7 @@ export class ActionBase {
     this.negativeEntities = action.negativeEntities || []
     this.requiredConditions = action.requiredConditions || []
     this.negativeConditions = action.negativeConditions || []
-    this.suggestedEntity = action.suggestedEntity || null
+    this.suggestedEntity = action.suggestedEntity
     this.version = action.version
     this.packageCreationId = action.packageCreationId
     this.packageDeletionId = action.packageDeletionId


### PR DESCRIPTION
Server doesn't return `suggestedEntity` unless it's set, need the models to match for change in UI.

Prefer server to always return the same shaped objects but Shahin prefers the other way so change the ui to match.