### PR TITLE
fix: memory resolution type can be null when builtin is set

### DIFF
--- a/src/Memory.ts
+++ b/src/Memory.ts
@@ -6,7 +6,7 @@ export interface MemoryValue {
   userText: string | null
   displayText: string | null
   builtinType: string | null
-  resolution: {}
+  resolution: {} | null
   enumValueId?: string | null
 }
 


### PR DESCRIPTION
Previously we had assumed a prebuilt entities (those with `builtinType`) had resolution as a JSON object `{}` but with these new typed `keyPhrase` and `personName` it can be `null`

Would be more appropriate to use type unions so you can only acccess the resolution after you check the `builtinType`. Will look at that.