### PR TITLE
fix: resolution can be null

### DIFF
--- a/src/Entity.ts
+++ b/src/Entity.ts
@@ -65,7 +65,7 @@ export interface LabeledEntity {
   startCharIndex: number
   endCharIndex: number
   entityText: string
-  resolution: {}
+  resolution: {} | null
   builtinType: string
 }
 


### PR DESCRIPTION
I only thought this was on `MemoryValue` but it's also shared on `LabeledEntity`.