### PR TITLE
 build: update circleci config to 2.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,4 @@
-version: 2
+version: 2.1
 jobs:
   build:
     docker:
@@ -27,7 +27,6 @@ jobs:
       - run: npm run report-coverage
 
 workflows:
-  version: 2
   build:
     jobs:
       - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,18 +9,19 @@ jobs:
       # Download and cache dependencies
       - restore_cache:
           keys:
-          - v1-dependencies-{{ checksum "package-lock.json" }}
-          # fallback to using the latest cache if no exact match is found
-          - v1-dependencies-
+            - v1-deps-{{ .Branch }}-{{ checksum "package.json" }}
+            - v1-deps-{{ .Branch }}
+            - v1-deps
 
       - run: node --version
       - run: npm --version
       - run: npm ci
 
       - save_cache:
+          key: v1-deps-{{ .Branch }}-{{ checksum "package.json" }}
           paths:
-            - node_modules
-          key: v1-dependencies-{{ checksum "package-lock.json" }}
+            - ~/.npm
+            - ~/.cache
 
       - run: npm run test 
       - run: npm run build


### PR DESCRIPTION
I updated the UI to 2.1 to get the feature to auto cancel redundant builds but didn't do it for the rest of the repos.

Also looking into the "only builds PRs" configuration.  From what I understand from their docs, this setting is configured on their service instead of this file.