### PR TITLE
feat: add importId to TrainScorerStep

### DIFF
--- a/src/Action.ts
+++ b/src/Action.ts
@@ -70,11 +70,11 @@ export class ActionBase {
     this.isTerminal = action.isTerminal
     this.isEntryNode = action.isEntryNode
     this.repromptActionId = action.repromptActionId
-    this.requiredEntitiesFromPayload = action.requiredEntitiesFromPayload || []
-    this.requiredEntities = action.requiredEntities || []
-    this.negativeEntities = action.negativeEntities || []
-    this.requiredConditions = action.requiredConditions || []
-    this.negativeConditions = action.negativeConditions || []
+    this.requiredEntitiesFromPayload = action.requiredEntitiesFromPayload
+    this.requiredEntities = action.requiredEntities
+    this.negativeEntities = action.negativeEntities
+    this.requiredConditions = action.requiredConditions
+    this.negativeConditions = action.negativeConditions
     this.suggestedEntity = action.suggestedEntity
     this.version = action.version
     this.packageCreationId = action.packageCreationId

--- a/src/TrainDialog.ts
+++ b/src/TrainDialog.ts
@@ -2,10 +2,11 @@
  * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License.
  */
-import { ScoreInput, ScoredAction, ScoreResponse } from './Score'
-import { LabeledEntity } from './Entity'
+import { Condition } from './Action'
 import { AppDefinition } from './AppDefinition'
+import { LabeledEntity } from './Entity'
 import { FilledEntity } from './FilledEntity'
+import { ScoreInput, ScoredAction, ScoreResponse } from './Score'
 
 export const MAX_TEXT_VARIATIONS = 20
 
@@ -45,6 +46,8 @@ export interface TrainScorerStep {
   importText?: string
   // Used for UI rendering only
   uiScoreResponse?: ScoreResponse
+  // If set, this action should be created with the specified condition(s).
+  requiredConditions?: Condition[]
 }
 
 export interface TrainRound {

--- a/src/TrainDialog.ts
+++ b/src/TrainDialog.ts
@@ -2,7 +2,6 @@
  * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License.
  */
-import { Condition } from './Action'
 import { AppDefinition } from './AppDefinition'
 import { LabeledEntity } from './Entity'
 import { FilledEntity } from './FilledEntity'

--- a/src/TrainDialog.ts
+++ b/src/TrainDialog.ts
@@ -46,8 +46,8 @@ export interface TrainScorerStep {
   importText?: string
   // Used for UI rendering only
   uiScoreResponse?: ScoreResponse
-  // If set, this action should be created with the specified condition(s).
-  requiredConditions?: Condition[]
+  // May be set during TrainDialog import to uniquely identify this scorer step.
+  importId?: string
 }
 
 export interface TrainRound {


### PR DESCRIPTION
Adds `importId` to `TrainScorerStep` to support import of .dialog files with SwitchCondition nodes.

SwitchConditions may have clauses like `productType == WINDOWS` and `productType == OFFICE`, where `productType` can be set as the result of an API call.

When we generate a TrainDialog from a dialog tree with this type of structure, we will create an enum entity called `productType` to store each potential returned value of the API call, in this case `WINDOWS` and `OFFICE`.

We would like to set the appropriate enum entity value as a required condition on the next action generated from the dialog tree.  However, _actions_ are created as a secondary pass after a `TrainDialog` is generated.  Eg, there is an interactive or automated pass where each `TrainDialog` step is either matched to an existing action, or a new action is created.

This PR adds the ability to assign a unique id to each `TrainScorerStep`, which can be used to associate the scorer step with required conditions during action generation.

The PR also fixes some linter warnings.